### PR TITLE
hotfix

### DIFF
--- a/components/Masthead/Masthead.module.scss
+++ b/components/Masthead/Masthead.module.scss
@@ -47,13 +47,14 @@ $navHeight: 95px;
 
 .title{
     display: flex;
-    gap: spacing(4);
+    gap: spacing(2);
     font-size: rem(32);
     font-family: $cornerstone;
     color:$white;
     text-shadow: -2px 1px 18px rgba(0,0,0, 1);
 
     @include bp(medium){
+        gap: spacing(4);
         font-size: rem(70);
     }
 }

--- a/styles/pages/about/about.module.scss
+++ b/styles/pages/about/about.module.scss
@@ -66,12 +66,16 @@
     }
 
     .inner{
+        text-align: left;
+
         @include bp(medium){
             position:absolute;
             top:50%;
             left:0;
             transform:translateY(-50%);
             padding:0;
+            
+
         }
     }
 


### PR DESCRIPTION
minimize gap in page titles, text-align to left for about text mobile